### PR TITLE
Acerta função para definir fuso horário no bootstrap

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -22,4 +22,4 @@ if ($isDevMode) {
     error_reporting(-1);
 }
 
-date_default_timezone_get($c->timezone);
+date_default_timezone_set($c->timezone);


### PR DESCRIPTION
Estava usando a função `date_default_timezone_get` para definição.

Relacionado com o esqueleto do projeto, #1 
