### PR TITLE
Remove php_mess_detector do scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -22,13 +22,4 @@ tools:
     php_loc:
         enabled: false
         excluded_dirs: [config/*, public/*, vagrant/*, vendor/*]
-    php_mess_detector:
-        config:
-            rulesets:
-                - cleancode
-                - codesize
-                - controversial
-                - design
-                - naming
-                - unusedcode
     php_analyzer: true


### PR DESCRIPTION
Com ele, o scrutinizer inteiro falhava.

No futuro, devemos colocar de novo. (@duodraco, uma ajuda aqui?)
